### PR TITLE
feat: Add comprehensive unit test coverage for all components and services (WIP)

### DIFF
--- a/src/app/complete/complete.page.spec.ts
+++ b/src/app/complete/complete.page.spec.ts
@@ -1,0 +1,304 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CompletePage } from './complete.page';
+import { Router } from '@angular/router';
+import { HeaderComponent } from '@components/header/header.component';
+import { MmCardComponent } from '@components/mm-card/mm-card.component';
+import { IonHeader, IonContent, IonButton, ModalController } from '@ionic/angular/standalone';
+import { By } from '@angular/platform-browser';
+
+describe('CompletePage', () => {
+  let component: CompletePage;
+  let fixture: ComponentFixture<CompletePage>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockModalController: jasmine.SpyObj<ModalController>;
+
+  beforeEach(async () => {
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockModalController = jasmine.createSpyObj('ModalController', ['create']);
+
+    // Mock window.open
+    spyOn(window, 'open').and.returnValue(null);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        CompletePage,
+        IonHeader,
+        IonContent,
+        IonButton,
+        HeaderComponent,
+        MmCardComponent
+      ],
+      providers: [
+        { provide: Router, useValue: mockRouter },
+        { provide: ModalController, useValue: mockModalController }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CompletePage);
+    component = fixture.componentInstance;
+  });
+
+  describe('Component Initialization', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should inject Router service', () => {
+      expect(component['router']).toBeDefined();
+    });
+
+    it('should have correct template structure', () => {
+      fixture.detectChanges();
+      
+      const header = fixture.debugElement.query(By.css('ion-header'));
+      const content = fixture.debugElement.query(By.css('ion-content'));
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      const card = fixture.debugElement.query(By.css('app-mm-card'));
+      const headerComponent = fixture.debugElement.query(By.css('app-header'));
+
+      expect(header).toBeTruthy();
+      expect(content).toBeTruthy();
+      expect(button).toBeTruthy();
+      expect(card).toBeTruthy();
+      expect(headerComponent).toBeTruthy();
+    });
+  });
+
+  describe('Header Configuration', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should configure header component correctly', () => {
+      const headerComponent = fixture.debugElement.query(By.css('app-header'));
+      expect(headerComponent.componentInstance.showBackButton()).toBe(true);
+      expect(headerComponent.componentInstance.showInboxButton()).toBe(true);
+    });
+
+    it('should handle back event from header', () => {
+      spyOn(component, 'navigateBack');
+      
+      const headerComponent = fixture.debugElement.query(By.css('app-header'));
+      headerComponent.componentInstance.backEvent.emit();
+      
+      expect(component.navigateBack).toHaveBeenCalled();
+    });
+
+    it('should set correct header attributes', () => {
+      const header = fixture.debugElement.query(By.css('ion-header'));
+      expect(header.nativeElement.getAttribute('mode')).toBe('ios');
+      expect(header.nativeElement.classList).toContain('ion-no-border');
+    });
+  });
+
+  describe('Card Content', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should configure mm-card component correctly', () => {
+      const cardComponent = fixture.debugElement.query(By.css('app-mm-card'));
+      expect(cardComponent.componentInstance.title()).toBe('Assessment Complete!');
+    });
+
+    it('should display correct card content', () => {
+      const cardContent = fixture.debugElement.query(By.css('app-mm-card'));
+      const textContent = cardContent.nativeElement.textContent;
+      
+      expect(textContent).toContain('Congratulations on completing the Mama Money Frontend Technical Assessment!');
+      expect(textContent).toContain('We value your feedback and would appreciate your thoughts');
+      expect(textContent).toContain('Providing feedback is optional but greatly appreciated');
+    });
+
+    it('should have proper text formatting', () => {
+      const card = fixture.debugElement.query(By.css('app-mm-card'));
+      const paragraphs = card.queryAll(By.css('p'));
+      
+      expect(paragraphs.length).toBe(3);
+      expect(paragraphs[0].nativeElement.classList).toContain('m-b-2');
+      expect(paragraphs[1].nativeElement.classList).toContain('m-b-2');
+      
+      const strongElement = card.query(By.css('strong'));
+      expect(strongElement).toBeTruthy();
+      expect(strongElement.nativeElement.textContent).toBe('Note:');
+      
+      const italicElement = card.query(By.css('i'));
+      expect(italicElement).toBeTruthy();
+    });
+  });
+
+  describe('Feedback Button', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should configure button correctly', () => {
+      // Get the feedback button specifically (not the header back button)
+      const buttons = fixture.debugElement.queryAll(By.css('ion-button'));
+      const feedbackButton = buttons.find(btn => 
+        btn.nativeElement.textContent.includes('Share Your Feedback')
+      );
+      
+      expect(feedbackButton).toBeTruthy();
+      expect(feedbackButton!.nativeElement.getAttribute('color')).toBe('secondary');
+      expect(feedbackButton!.nativeElement.getAttribute('expand')).toBe('block');
+      expect(feedbackButton!.nativeElement.getAttribute('size')).toBe('large');
+      expect(feedbackButton!.nativeElement.getAttribute('fill')).toBe('solid');
+      expect(feedbackButton!.nativeElement.classList).toContain('m-t-4');
+    });
+
+    it('should display correct button text', () => {
+      const buttons = fixture.debugElement.queryAll(By.css('ion-button'));
+      const feedbackButton = buttons.find(btn => 
+        btn.nativeElement.textContent.includes('Share Your Feedback')
+      );
+      
+      expect(feedbackButton).toBeTruthy();
+      expect(feedbackButton!.nativeElement.textContent.trim()).toBe('Share Your Feedback');
+    });
+
+    it('should call openSurvey when clicked', () => {
+      spyOn(component, 'openSurvey');
+      
+      const buttons = fixture.debugElement.queryAll(By.css('ion-button'));
+      const feedbackButton = buttons.find(btn => 
+        btn.nativeElement.textContent.includes('Share Your Feedback')
+      );
+      
+      expect(feedbackButton).toBeTruthy();
+      feedbackButton!.nativeElement.click();
+      
+      expect(component.openSurvey).toHaveBeenCalled();
+    });
+  });
+
+  describe('Layout and Styling', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should apply correct CSS classes to content', () => {
+      const content = fixture.debugElement.query(By.css('ion-content'));
+      expect(content.nativeElement.getAttribute('fullscreen')).toBe('true');
+      expect(content.nativeElement.classList).toContain('ion-padding');
+    });
+
+    it('should apply correct margin to button', () => {
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      expect(button.nativeElement.classList).toContain('m-t-4');
+    });
+  });
+
+  describe('Navigation Methods', () => {
+    it('should navigate back when navigateBack is called', () => {
+      component.navigateBack();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+    });
+
+    it('should handle navigation error gracefully', () => {
+      mockRouter.navigate.and.returnValue(Promise.reject(new Error('Navigation failed')));
+      
+      expect(() => component.navigateBack()).not.toThrow();
+    });
+  });
+
+  describe('Survey Methods', () => {
+    it('should have openSurvey method', () => {
+      expect(component.openSurvey).toBeDefined();
+      expect(typeof component.openSurvey).toBe('function');
+    });
+
+    it('should not throw error when openSurvey is called', () => {
+      expect(() => component.openSurvey()).not.toThrow();
+    });
+
+    it('should call window.open with correct URL', () => {
+      component.openSurvey();
+      
+      expect(window.open).toHaveBeenCalledWith('https://forms.gle/UazsbVmJx215Litc9', '_blank');
+    });
+  });
+
+  describe('Component Structure', () => {
+    it('should be a standalone component', () => {
+      expect(CompletePage).toBeDefined();
+      // Verify it's imported in the component metadata
+      const componentMetadata = fixture.componentRef.componentType as any;
+      expect(componentMetadata).toBeDefined();
+    });
+
+    it('should import all required Ionic components', () => {
+      fixture.detectChanges();
+      
+      expect(fixture.debugElement.query(By.css('ion-header'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('ion-content'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('ion-button'))).toBeTruthy();
+    });
+
+    it('should import custom components', () => {
+      fixture.detectChanges();
+      
+      expect(fixture.debugElement.query(By.css('app-header'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('app-mm-card'))).toBeTruthy();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle missing Router service gracefully', () => {
+      // This test ensures the component can handle DI issues
+      expect(component['router']).toBeDefined();
+    });
+
+    it('should continue execution if survey fails to open', () => {
+      (window.open as jasmine.Spy).and.throwError('Failed to open');
+      
+      expect(() => component.openSurvey()).not.toThrow();
+    });
+  });
+
+  describe('User Experience', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should provide clear completion message', () => {
+      const cardContent = fixture.debugElement.query(By.css('app-mm-card'));
+      const textContent = cardContent.nativeElement.textContent;
+      
+      expect(textContent).toContain('Assessment Complete!');
+      expect(textContent).toContain('Congratulations');
+    });
+
+    it('should make feedback optional and clear', () => {
+      const cardContent = fixture.debugElement.query(By.css('app-mm-card'));
+      const textContent = cardContent.nativeElement.textContent;
+      
+      expect(textContent).toContain('optional but greatly appreciated');
+    });
+
+    it('should provide accessible button text', () => {
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      expect(button.nativeElement.textContent.trim()).toBe('Share Your Feedback');
+    });
+  });
+
+  describe('Component Lifecycle', () => {
+    it('should not implement unnecessary lifecycle hooks', () => {
+      // Component should be simple and not need lifecycle hooks
+      expect('ngOnInit' in component).toBe(false);
+      expect('ngOnDestroy' in component).toBe(false);
+    });
+
+    it('should be stateless', () => {
+      // Component should not have any state properties
+      const componentProps = Object.getOwnPropertyNames(component);
+      const stateProps = componentProps.filter(prop => 
+        !prop.startsWith('_') && 
+        prop !== 'router' && 
+        typeof (component as any)[prop] !== 'function'
+      );
+      
+      expect(stateProps.length).toBe(0);
+    });
+  });
+});

--- a/src/app/home/home.page.spec.ts
+++ b/src/app/home/home.page.spec.ts
@@ -1,0 +1,219 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HomePage } from './home.page';
+import { BrazeService } from '@services/braze.service';
+import { PushNotificationService } from '@services/push-notification.service';
+import { HeaderComponent } from '@components/header/header.component';
+import { MmCardComponent } from '@components/mm-card/mm-card.component';
+import { IonHeader, IonContent, IonButton } from '@ionic/angular/standalone';
+import { By } from '@angular/platform-browser';
+
+describe('HomePage', () => {
+  let component: HomePage;
+  let fixture: ComponentFixture<HomePage>;
+  let mockBrazeService: jasmine.SpyObj<BrazeService>;
+  let mockPushNotificationService: jasmine.SpyObj<PushNotificationService>;
+
+  beforeEach(async () => {
+    // Create service mocks
+    mockBrazeService = jasmine.createSpyObj('BrazeService', ['logCustomEvent']);
+    mockPushNotificationService = jasmine.createSpyObj('PushNotificationService', ['init']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        HomePage,
+        IonHeader,
+        IonContent,
+        IonButton,
+        HeaderComponent,
+        MmCardComponent
+      ],
+      providers: [
+        { provide: BrazeService, useValue: mockBrazeService },
+        { provide: PushNotificationService, useValue: mockPushNotificationService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomePage);
+    component = fixture.componentInstance;
+  });
+
+  describe('Component Initialization', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should initialize push notification service on construction', () => {
+      expect(mockPushNotificationService.init).toHaveBeenCalled();
+    });
+
+    it('should have correct template structure', () => {
+      fixture.detectChanges();
+      
+      const header = fixture.debugElement.query(By.css('ion-header'));
+      const content = fixture.debugElement.query(By.css('ion-content'));
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      const card = fixture.debugElement.query(By.css('app-mm-card'));
+      const headerComponent = fixture.debugElement.query(By.css('app-header'));
+
+      expect(header).toBeTruthy();
+      expect(content).toBeTruthy();
+      expect(button).toBeTruthy();
+      expect(card).toBeTruthy();
+      expect(headerComponent).toBeTruthy();
+    });
+
+    it('should set correct attributes on header component', () => {
+      fixture.detectChanges();
+      
+      const headerComponent = fixture.debugElement.query(By.css('app-header'));
+      expect(headerComponent.componentInstance.showInboxButton()).toBe(true);
+    });
+
+    it('should set correct attributes on mm-card component', () => {
+      fixture.detectChanges();
+      
+      const cardComponent = fixture.debugElement.query(By.css('app-mm-card'));
+      expect(cardComponent.componentInstance.title()).toBe('Implementation Task');
+    });
+
+    it('should set correct attributes on button', () => {
+      fixture.detectChanges();
+      
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      expect(button.nativeElement.getAttribute('color')).toBe('primary');
+      expect(button.nativeElement.getAttribute('expand')).toBe('block');
+      expect(button.nativeElement.getAttribute('size')).toBe('large');
+      expect(button.nativeElement.getAttribute('fill')).toBe('solid');
+    });
+  });
+
+  describe('sendInboxTestEvent', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should call brazeService.logCustomEvent with correct parameters', async () => {
+      mockBrazeService.logCustomEvent.and.returnValue(Promise.resolve());
+      
+      await component.sendInboxTestEvent();
+      
+      expect(mockBrazeService.logCustomEvent).toHaveBeenCalledWith(
+        'INBOX_MESSAGE_TEST',
+        jasmine.objectContaining({
+          source: 'homepage',
+          timestamp: jasmine.any(String)
+        })
+      );
+    });
+
+    it('should handle successful event sending', async () => {
+      mockBrazeService.logCustomEvent.and.returnValue(Promise.resolve());
+      spyOn(console, 'log');
+      
+      await component.sendInboxTestEvent();
+      
+      expect(console.log).toHaveBeenCalledWith('Sending INBOX_MESSAGE_TEST event to Braze...');
+      expect(console.log).toHaveBeenCalledWith('INBOX_MESSAGE_TEST event sent successfully');
+    });
+
+    it('should handle error when event sending fails', async () => {
+      const error = new Error('Network error');
+      mockBrazeService.logCustomEvent.and.returnValue(Promise.reject(error));
+      spyOn(console, 'error');
+      
+      await component.sendInboxTestEvent();
+      
+      expect(console.error).toHaveBeenCalledWith('Error sending test event:', error);
+    });
+
+    it('should be called when button is clicked', async () => {
+      spyOn(component, 'sendInboxTestEvent');
+      
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      button.nativeElement.click();
+      
+      expect(component.sendInboxTestEvent).toHaveBeenCalled();
+    });
+
+    it('should include current timestamp in event properties', async () => {
+      mockBrazeService.logCustomEvent.and.returnValue(Promise.resolve());
+      const beforeTime = Date.now();
+      
+      await component.sendInboxTestEvent();
+      
+      const afterTime = Date.now();
+      const callArgs = mockBrazeService.logCustomEvent.calls.mostRecent().args;
+      const properties = callArgs[1] as { [key: string]: any };
+      
+      expect(properties).toBeDefined();
+      expect(properties['timestamp']).toBeDefined();
+      
+      const eventTime = new Date(properties['timestamp']).getTime();
+      expect(eventTime).toBeGreaterThanOrEqual(beforeTime);
+      expect(eventTime).toBeLessThanOrEqual(afterTime);
+    });
+  });
+
+  describe('Template Content', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should display correct card content', () => {
+      const cardContent = fixture.debugElement.query(By.css('app-mm-card'));
+      const textContent = cardContent.nativeElement.textContent;
+      
+      expect(textContent).toContain('Implement functionality to send INBOX_MESSAGE_TEST custom event to Braze');
+      expect(textContent).toContain('Braze will send a push notification back');
+      expect(textContent).toContain('Push notifications may take awhile to arrive');
+    });
+
+    it('should display correct button text', () => {
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      expect(button.nativeElement.textContent.trim()).toBe('Send Test Event');
+    });
+
+    it('should have correct CSS classes applied', () => {
+      const content = fixture.debugElement.query(By.css('ion-content'));
+      const button = fixture.debugElement.query(By.css('ion-button'));
+      
+      expect(content.nativeElement.classList).toContain('ion-padding');
+      expect(button.nativeElement.classList).toContain('m-t-4');
+    });
+  });
+
+  describe('Service Integration', () => {
+    it('should have injected services available', () => {
+      expect(component['brazeService']).toBeDefined();
+      expect(component['pushNotificationService']).toBeDefined();
+    });
+
+    it('should call push notification service init only once during construction', () => {
+      // Service should be called once during component construction
+      expect(mockPushNotificationService.init).toHaveBeenCalledTimes(1);
+      
+      // Creating another instance should call it again
+      const newFixture = TestBed.createComponent(HomePage);
+      expect(mockPushNotificationService.init).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should not throw error if BrazeService is unavailable', async () => {
+      mockBrazeService.logCustomEvent.and.returnValue(Promise.reject(new Error('Service unavailable')));
+      
+      expect(async () => await component.sendInboxTestEvent()).not.toThrow();
+    });
+
+    it('should continue execution after logging error', async () => {
+      mockBrazeService.logCustomEvent.and.returnValue(Promise.reject(new Error('Network error')));
+      spyOn(console, 'log');
+      spyOn(console, 'error');
+      
+      await component.sendInboxTestEvent();
+      
+      expect(console.log).toHaveBeenCalledWith('Sending INBOX_MESSAGE_TEST event to Braze...');
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/shared/components/inbox/inbox.component.spec.ts
+++ b/src/app/shared/components/inbox/inbox.component.spec.ts
@@ -1,0 +1,391 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InboxComponent } from './inbox.component';
+import { InboxService } from '@services/inbox.service';
+import { BrazeService, BrazeContentCard } from '@services/braze.service';
+import { Router } from '@angular/router';
+import { AlertController, ModalController } from '@ionic/angular/standalone';
+import { MmCardComponent } from '../mm-card/mm-card.component';
+import { signal } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+describe('InboxComponent', () => {
+  let component: InboxComponent;
+  let fixture: ComponentFixture<InboxComponent>;
+  let mockInboxService: jasmine.SpyObj<InboxService>;
+  let mockBrazeService: jasmine.SpyObj<BrazeService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockModalController: jasmine.SpyObj<ModalController>;
+  let mockAlertController: jasmine.SpyObj<AlertController>;
+
+  const mockCard: BrazeContentCard = {
+    id: '1',
+    title: 'Test Card',
+    cardDescription: 'Test Description',
+    created: Date.now() / 1000,
+    expiresAt: Date.now() / 1000 + 3600,
+    viewed: false,
+    clicked: false,
+    pinned: false,
+    dismissed: false,
+    dismissible: true,
+    openURLInWebView: false,
+    domain: 'test.com',
+    type: 'CLASSIC',
+    extras: {},
+    image: undefined,
+    url: undefined
+  };
+
+  const mockCard2: BrazeContentCard = {
+    ...mockCard,
+    id: '2',
+    title: 'Second Card',
+    cardDescription: 'Second Description'
+  };
+
+  beforeEach(async () => {
+    // Create service mocks
+    mockInboxService = jasmine.createSpyObj('InboxService', ['markAsViewed', 'dismissCard']);
+    mockBrazeService = jasmine.createSpyObj('BrazeService', [
+      'logContentCardImpression',
+      'logContentCardDismissed'
+    ]);
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockModalController = jasmine.createSpyObj('ModalController', ['dismiss']);
+    mockAlertController = jasmine.createSpyObj('AlertController', ['create']);
+
+    // Setup inbox service with signal
+    const cardsSignal = signal<BrazeContentCard[]>([]);
+    Object.defineProperty(mockInboxService, 'cards', {
+      get: () => cardsSignal.asReadonly()
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [InboxComponent, MmCardComponent],
+      providers: [
+        { provide: InboxService, useValue: mockInboxService },
+        { provide: BrazeService, useValue: mockBrazeService },
+        { provide: Router, useValue: mockRouter },
+        { provide: ModalController, useValue: mockModalController },
+        { provide: AlertController, useValue: mockAlertController }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InboxComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('Component Initialization', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should initialize with inbox service cards', () => {
+      expect(component.inboxCards).toBeDefined();
+      expect(component.inboxCards()).toEqual([]);
+    });
+
+    it('should have correct template structure', () => {
+      fixture.detectChanges();
+      
+      const header = fixture.debugElement.query(By.css('ion-header'));
+      const toolbar = fixture.debugElement.query(By.css('ion-toolbar'));
+      const title = fixture.debugElement.query(By.css('ion-title'));
+      const content = fixture.debugElement.query(By.css('ion-content'));
+      const backButton = fixture.debugElement.query(By.css('.back-btn'));
+
+      expect(header).toBeTruthy();
+      expect(toolbar).toBeTruthy();
+      expect(title).toBeTruthy();
+      expect(content).toBeTruthy();
+      expect(backButton).toBeTruthy();
+    });
+
+    it('should display correct title', () => {
+      fixture.detectChanges();
+      
+      const title = fixture.debugElement.query(By.css('ion-title'));
+      expect(title.nativeElement.textContent.trim()).toBe('Notifications');
+    });
+  });
+
+  describe('Empty State', () => {
+    it('should show empty state when no cards are present', () => {
+      fixture.detectChanges();
+      
+      const emptyState = fixture.debugElement.query(By.css('.empty-state'));
+      const cards = fixture.debugElement.queryAll(By.css('app-mm-card'));
+      
+      expect(emptyState).toBeTruthy();
+      expect(cards.length).toBe(0);
+      expect(emptyState.nativeElement.textContent.trim()).toContain('You\'re all caught up! No new notifications.');
+    });
+
+    it('should hide empty state when cards are present', () => {
+      // Add cards to the signal
+      const cardsSignal = signal<BrazeContentCard[]>([mockCard]);
+      Object.defineProperty(mockInboxService, 'cards', {
+        get: () => cardsSignal.asReadonly()
+      });
+      
+      fixture = TestBed.createComponent(InboxComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      
+      const emptyState = fixture.debugElement.query(By.css('.empty-state'));
+      const cards = fixture.debugElement.queryAll(By.css('app-mm-card'));
+      
+      expect(emptyState).toBeFalsy();
+      expect(cards.length).toBe(1);
+    });
+  });
+
+  describe('Card Display', () => {
+    beforeEach(() => {
+      // Setup cards in the service
+      const cardsSignal = signal<BrazeContentCard[]>([mockCard, mockCard2]);
+      Object.defineProperty(mockInboxService, 'cards', {
+        get: () => cardsSignal.asReadonly()
+      });
+      
+      fixture = TestBed.createComponent(InboxComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should display cards when available', () => {
+      const cards = fixture.debugElement.queryAll(By.css('app-mm-card'));
+      expect(cards.length).toBe(2);
+    });
+
+    it('should configure mm-card components correctly', () => {
+      const cards = fixture.debugElement.queryAll(By.css('app-mm-card'));
+      
+      const firstCard = cards[0].componentInstance;
+      expect(firstCard.title()).toBe('Test Card');
+      expect(firstCard.showIcon()).toBe(true);
+      expect(firstCard.showDeleteButton()).toBe(true);
+      
+      const secondCard = cards[1].componentInstance;
+      expect(secondCard.title()).toBe('Second Card');
+    });
+
+    it('should use default title when card title is missing', () => {
+      const cardWithoutTitle = { ...mockCard, title: undefined };
+      const cardsSignal = signal<BrazeContentCard[]>([cardWithoutTitle]);
+      Object.defineProperty(mockInboxService, 'cards', {
+        get: () => cardsSignal.asReadonly()
+      });
+      
+      fixture = TestBed.createComponent(InboxComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      
+      const card = fixture.debugElement.query(By.css('app-mm-card'));
+      expect(card.componentInstance.title()).toBe('Notification');
+    });
+
+    it('should display card description', () => {
+      const cardMessages = fixture.debugElement.queryAll(By.css('.card-message'));
+      expect(cardMessages[0].nativeElement.textContent.trim()).toBe('Test Description');
+      expect(cardMessages[1].nativeElement.textContent.trim()).toBe('Second Description');
+    });
+
+    it('should display default description when missing', () => {
+      const cardWithoutDescription = { ...mockCard, cardDescription: undefined };
+      const cardsSignal = signal<BrazeContentCard[]>([cardWithoutDescription]);
+      Object.defineProperty(mockInboxService, 'cards', {
+        get: () => cardsSignal.asReadonly()
+      });
+      
+      fixture = TestBed.createComponent(InboxComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      
+      const cardMessage = fixture.debugElement.query(By.css('.card-message'));
+      expect(cardMessage.nativeElement.textContent.trim()).toBe('No description available');
+    });
+
+    it('should display formatted timestamp', () => {
+      const timestamps = fixture.debugElement.queryAll(By.css('.card-timestamp'));
+      expect(timestamps.length).toBe(2);
+      expect(timestamps[0].nativeElement.textContent.trim()).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/); // Date format
+    });
+  });
+
+  describe('Card Interactions', () => {
+    beforeEach(() => {
+      const cardsSignal = signal<BrazeContentCard[]>([mockCard]);
+      Object.defineProperty(mockInboxService, 'cards', {
+        get: () => cardsSignal.asReadonly()
+      });
+      
+      fixture = TestBed.createComponent(InboxComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should handle card click', async () => {
+      mockBrazeService.logContentCardImpression.and.returnValue(Promise.resolve());
+      
+      const cardContent = fixture.debugElement.query(By.css('.inbox-card'));
+      cardContent.nativeElement.click();
+      
+      expect(mockInboxService.markAsViewed).toHaveBeenCalledWith('1');
+    });
+
+    it('should log impression and navigate on card click', async () => {
+      mockBrazeService.logContentCardImpression.and.returnValue(Promise.resolve());
+      
+      await component.onCardClick(mockCard);
+      
+      expect(mockInboxService.markAsViewed).toHaveBeenCalledWith('1');
+      expect(mockBrazeService.logContentCardImpression).toHaveBeenCalledWith('1');
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/complete']);
+    });
+
+    it('should handle error during card click', async () => {
+      const error = new Error('Network error');
+      mockBrazeService.logContentCardImpression.and.returnValue(Promise.reject(error));
+      spyOn(console, 'error');
+      
+      await component.onCardClick(mockCard);
+      
+      expect(console.error).toHaveBeenCalledWith('Error logging card interaction:', error);
+    });
+  });
+
+  describe('Card Dismissal', () => {
+    let mockAlert: jasmine.SpyObj<HTMLIonAlertElement>;
+
+    beforeEach(() => {
+      mockAlert = jasmine.createSpyObj('HTMLIonAlertElement', ['present']);
+      mockAlertController.create.and.returnValue(Promise.resolve(mockAlert));
+      
+      const cardsSignal = signal<BrazeContentCard[]>([mockCard]);
+      Object.defineProperty(mockInboxService, 'cards', {
+        get: () => cardsSignal.asReadonly()
+      });
+      
+      fixture = TestBed.createComponent(InboxComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should show confirmation dialog when dismiss card is called', async () => {
+      await component.dismissCard(mockCard);
+      
+      expect(mockAlertController.create).toHaveBeenCalledWith({
+        header: 'Delete Message',
+        message: 'Are you sure you would like to delete this message?',
+        buttons: jasmine.arrayContaining([
+          jasmine.objectContaining({ text: 'No', role: 'cancel' }),
+          jasmine.objectContaining({ text: 'Yes' })
+        ])
+      });
+      expect(mockAlert.present).toHaveBeenCalled();
+    });
+
+    it('should call confirmDismiss when Yes is clicked in alert', async () => {
+      spyOn(component, 'confirmDismiss' as any);
+      
+      await component.dismissCard(mockCard);
+      
+      const createCall = mockAlertController.create.calls.mostRecent();
+      const alertConfig = createCall.args[0];
+      const yesButton = alertConfig?.buttons?.find((btn: any) => btn.text === 'Yes') as any;
+      
+      expect(yesButton).toBeDefined();
+      expect(yesButton.handler).toBeDefined();
+      
+      yesButton.handler();
+      expect(component['confirmDismiss']).toHaveBeenCalledWith(mockCard);
+    });
+
+    it('should delete button trigger dismissCard', () => {
+      spyOn(component, 'dismissCard');
+      
+      const mmCard = fixture.debugElement.query(By.css('app-mm-card'));
+      mmCard.componentInstance.deleteClick.emit();
+      
+      expect(component.dismissCard).toHaveBeenCalledWith(mockCard);
+    });
+  });
+
+  describe('Confirm Dismiss', () => {
+    it('should log dismissal and remove card successfully', async () => {
+      mockBrazeService.logContentCardDismissed.and.returnValue(Promise.resolve());
+      
+      await component['confirmDismiss'](mockCard);
+      
+      expect(mockBrazeService.logContentCardDismissed).toHaveBeenCalledWith('1');
+      expect(mockInboxService.dismissCard).toHaveBeenCalledWith('1');
+    });
+
+    it('should remove card from local state even if Braze logging fails', async () => {
+      const error = new Error('Network error');
+      mockBrazeService.logContentCardDismissed.and.returnValue(Promise.reject(error));
+      spyOn(console, 'error');
+      
+      await component['confirmDismiss'](mockCard);
+      
+      expect(console.error).toHaveBeenCalledWith('Error dismissing card:', error);
+      expect(mockInboxService.dismissCard).toHaveBeenCalledWith('1');
+    });
+  });
+
+  describe('Modal Dismissal', () => {
+    it('should dismiss modal when back button is clicked', () => {
+      const backButton = fixture.debugElement.query(By.css('.back-btn'));
+      backButton.nativeElement.click();
+      
+      expect(mockModalController.dismiss).toHaveBeenCalled();
+    });
+
+    it('should dismiss modal when confirmDismissModal is called', () => {
+      component.confirmDismissModal();
+      expect(mockModalController.dismiss).toHaveBeenCalled();
+    });
+  });
+
+  describe('Date Formatting', () => {
+    it('should format date correctly', () => {
+      const timestamp = Date.now() / 1000; // Current time in seconds
+      const result = component.formatDate(timestamp);
+      
+      expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4} \d{1,2}:\d{2}/); // MM/DD/YYYY HH:MM format
+    });
+
+    it('should handle different timestamp formats', () => {
+      const timestamp = 1609459200; // January 1, 2021 00:00:00 UTC
+      const result = component.formatDate(timestamp);
+      
+      expect(result).toContain('2021');
+      expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
+    });
+  });
+
+  describe('Component Lifecycle', () => {
+    it('should implement OnInit', () => {
+      expect(component.ngOnInit).toBeDefined();
+    });
+
+    it('should not throw error during ngOnInit', () => {
+      expect(() => component.ngOnInit()).not.toThrow();
+    });
+  });
+
+  describe('Service Integration', () => {
+    it('should inject all required services', () => {
+      expect(component['modalController']).toBeDefined();
+      expect(component['alertController']).toBeDefined();
+      expect(component['inboxService']).toBeDefined();
+      expect(component['brazeService']).toBeDefined();
+      expect(component['router']).toBeDefined();
+    });
+
+    it('should use inbox service cards signal', () => {
+      expect(component.inboxCards).toBe(mockInboxService.cards);
+    });
+  });
+});

--- a/src/app/shared/components/mm-card/mm-card.component.spec.ts
+++ b/src/app/shared/components/mm-card/mm-card.component.spec.ts
@@ -1,0 +1,290 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MmCardComponent } from './mm-card.component';
+import { ImageLoaderComponent } from '@components/image-loader/image-loader.component';
+import { IonCard, IonCardHeader, IonCardTitle, IonCardContent, IonImg, IonButton, IonIcon } from '@ionic/angular/standalone';
+import { By } from '@angular/platform-browser';
+
+describe('MmCardComponent', () => {
+  let component: MmCardComponent;
+  let fixture: ComponentFixture<MmCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        MmCardComponent,
+        IonCard,
+        IonCardHeader,
+        IonCardTitle,
+        IonCardContent,
+        IonImg,
+        IonButton,
+        IonIcon,
+        ImageLoaderComponent
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MmCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('Component Initialization', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should have default input values', () => {
+      expect(component.title()).toBe('Mama Money');
+      expect(component.showIcon()).toBe(true);
+      expect(component.showDeleteButton()).toBe(false);
+    });
+
+    it('should register close icon', () => {
+      expect(() => new MmCardComponent()).not.toThrow();
+    });
+  });
+
+  describe('Template Rendering', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should render ion-card with correct class', () => {
+      const card = fixture.debugElement.query(By.css('ion-card'));
+      expect(card).toBeTruthy();
+      expect(card.nativeElement.classList).toContain('ion-no-padding');
+    });
+
+    it('should render card title when provided', () => {
+      const cardTitle = fixture.debugElement.query(By.css('ion-card-title'));
+      expect(cardTitle).toBeTruthy();
+      expect(cardTitle.nativeElement.textContent.trim()).toContain('Mama Money');
+    });
+
+    it('should render custom title when set', () => {
+      fixture.componentRef.setInput('title', 'Custom Title');
+      fixture.detectChanges();
+      
+      const cardTitle = fixture.debugElement.query(By.css('ion-card-title'));
+      expect(cardTitle.nativeElement.textContent.trim()).toContain('Custom Title');
+    });
+
+    it('should not render card header when title is empty', () => {
+      fixture.componentRef.setInput('title', '');
+      fixture.detectChanges();
+      
+      const cardTitle = fixture.debugElement.query(By.css('ion-card-title'));
+      expect(cardTitle).toBeFalsy();
+    });
+
+    it('should render content area', () => {
+      const cardContent = fixture.debugElement.query(By.css('ion-card-content'));
+      expect(cardContent).toBeTruthy();
+    });
+
+    it('should project content into ng-content', () => {
+      const testContent = '<p>Test content</p>';
+      fixture = TestBed.createComponent(MmCardComponent);
+      fixture.nativeElement.innerHTML = testContent;
+      fixture.detectChanges();
+      
+      const cardContent = fixture.debugElement.query(By.css('ion-card-content'));
+      expect(cardContent.nativeElement.innerHTML).toContain('ng-content');
+    });
+  });
+
+  describe('Icon Display', () => {
+    it('should show icon by default', () => {
+      fixture.detectChanges();
+      
+      const imageLoader = fixture.debugElement.query(By.css('app-image-loader'));
+      expect(imageLoader).toBeTruthy();
+    });
+
+    it('should hide icon when showIcon is false', () => {
+      fixture.componentRef.setInput('showIcon', false);
+      fixture.detectChanges();
+      
+      const imageLoader = fixture.debugElement.query(By.css('app-image-loader'));
+      expect(imageLoader).toBeFalsy();
+    });
+
+    it('should configure image loader correctly', () => {
+      fixture.detectChanges();
+      
+      const imageLoader = fixture.debugElement.query(By.css('app-image-loader'));
+      const imageLoaderComponent = imageLoader.componentInstance;
+      
+      expect(imageLoaderComponent.src).toBe('assets/icon/mm-cc-logo.png');
+      expect(imageLoaderComponent.imageClass).toBe('iconize');
+      expect(imageLoaderComponent.maxWidth).toBe('30px');
+      expect(imageLoaderComponent.skeletonDiameter).toBe('30px');
+      expect(imageLoaderComponent.skeletonBorderRadius).toBe('30px');
+    });
+  });
+
+  describe('Delete Button', () => {
+    it('should not show delete button by default', () => {
+      fixture.detectChanges();
+      
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).toBeFalsy();
+    });
+
+    it('should show delete button when showDeleteButton is true', () => {
+      fixture.componentRef.setInput('showDeleteButton', true);
+      fixture.detectChanges();
+      
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).toBeTruthy();
+    });
+
+    it('should have correct button attributes', () => {
+      fixture.componentRef.setInput('showDeleteButton', true);
+      fixture.detectChanges();
+      
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton.nativeElement.getAttribute('fill')).toBe('clear');
+      expect(deleteButton.nativeElement.getAttribute('size')).toBe('small');
+    });
+
+    it('should contain close icon', () => {
+      fixture.componentRef.setInput('showDeleteButton', true);
+      fixture.detectChanges();
+      
+      const icon = fixture.debugElement.query(By.css('.delete-button ion-icon'));
+      expect(icon).toBeTruthy();
+      expect(icon.nativeElement.getAttribute('name')).toBe('close');
+      expect(icon.nativeElement.getAttribute('slot')).toBe('icon-only');
+    });
+
+    it('should emit deleteClick event when clicked', () => {
+      fixture.componentRef.setInput('showDeleteButton', true);
+      fixture.detectChanges();
+      
+      spyOn(component.deleteClick, 'emit');
+      
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.nativeElement.click();
+      
+      expect(component.deleteClick.emit).toHaveBeenCalled();
+    });
+
+    it('should call onDeleteClick method when button is clicked', () => {
+      fixture.componentRef.setInput('showDeleteButton', true);
+      fixture.detectChanges();
+      
+      spyOn(component, 'onDeleteClick');
+      
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.nativeElement.click();
+      
+      expect(component.onDeleteClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('Layout and Styling', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('showDeleteButton', true);
+      fixture.detectChanges();
+    });
+
+    it('should use flex layout for title row', () => {
+      const titleContainer = fixture.debugElement.query(By.css('.flex-row.align-items-center.justify-content-between'));
+      expect(titleContainer).toBeTruthy();
+    });
+
+    it('should group icon and title together', () => {
+      const titleGroup = fixture.debugElement.query(By.css('.flex-row.align-items-center:not(.justify-content-between)'));
+      expect(titleGroup).toBeTruthy();
+      
+      const icon = titleGroup.query(By.css('app-image-loader'));
+      expect(icon).toBeTruthy();
+    });
+
+    it('should apply correct CSS classes to delete button', () => {
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton.nativeElement.classList).toContain('delete-button');
+    });
+
+    it('should apply margin to icon container', () => {
+      const iconContainer = fixture.debugElement.query(By.css('.m-r-1'));
+      expect(iconContainer).toBeTruthy();
+    });
+  });
+
+  describe('Input Changes', () => {
+    it('should update title when input changes', () => {
+      fixture.detectChanges();
+      
+      // Initial title
+      let cardTitle = fixture.debugElement.query(By.css('ion-card-title'));
+      expect(cardTitle.nativeElement.textContent.trim()).toContain('Mama Money');
+      
+      // Change title
+      fixture.componentRef.setInput('title', 'New Title');
+      fixture.detectChanges();
+      
+      cardTitle = fixture.debugElement.query(By.css('ion-card-title'));
+      expect(cardTitle.nativeElement.textContent.trim()).toContain('New Title');
+    });
+
+    it('should toggle icon visibility when showIcon changes', () => {
+      fixture.detectChanges();
+      
+      // Initially shown
+      let imageLoader = fixture.debugElement.query(By.css('app-image-loader'));
+      expect(imageLoader).toBeTruthy();
+      
+      // Hide icon
+      fixture.componentRef.setInput('showIcon', false);
+      fixture.detectChanges();
+      
+      imageLoader = fixture.debugElement.query(By.css('app-image-loader'));
+      expect(imageLoader).toBeFalsy();
+      
+      // Show icon again
+      fixture.componentRef.setInput('showIcon', true);
+      fixture.detectChanges();
+      
+      imageLoader = fixture.debugElement.query(By.css('app-image-loader'));
+      expect(imageLoader).toBeTruthy();
+    });
+
+    it('should toggle delete button visibility when showDeleteButton changes', () => {
+      fixture.detectChanges();
+      
+      // Initially hidden
+      let deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).toBeFalsy();
+      
+      // Show delete button
+      fixture.componentRef.setInput('showDeleteButton', true);
+      fixture.detectChanges();
+      
+      deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).toBeTruthy();
+      
+      // Hide delete button
+      fixture.componentRef.setInput('showDeleteButton', false);
+      fixture.detectChanges();
+      
+      deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).toBeFalsy();
+    });
+  });
+
+  describe('Component Methods', () => {
+    it('should have onDeleteClick method', () => {
+      expect(component.onDeleteClick).toBeDefined();
+      expect(typeof component.onDeleteClick).toBe('function');
+    });
+
+    it('should emit deleteClick event when onDeleteClick is called', () => {
+      spyOn(component.deleteClick, 'emit');
+      
+      component.onDeleteClick();
+      
+      expect(component.deleteClick.emit).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/shared/services/braze.service.spec.ts
+++ b/src/app/shared/services/braze.service.spec.ts
@@ -1,0 +1,238 @@
+import { TestBed } from '@angular/core/testing';
+import { BrazeService, BrazeContentCard } from './braze.service';
+
+describe('BrazeService', () => {
+  let service: BrazeService;
+  let mockPlugin: jasmine.SpyObj<any>;
+
+  beforeEach(() => {
+    // Create mock plugin with all necessary methods
+    mockPlugin = jasmine.createSpyObj('brazePlugin', [
+      'logCustomEvent',
+      'requestImmediateDataFlush',
+      'requestContentCardsRefresh',
+      'getContentCardsFromCache',
+      'logContentCardImpression',
+      'logContentCardClicked',
+      'logContentCardDismissed'
+    ]);
+
+    // Mock window.cordova.plugins.brazePlugin
+    (window as any).cordova = {
+      plugins: {
+        brazePlugin: mockPlugin
+      }
+    };
+
+    TestBed.configureTestingModule({
+      providers: [BrazeService]
+    });
+    service = TestBed.inject(BrazeService);
+  });
+
+  afterEach(() => {
+    // Clean up window mock
+    delete (window as any).cordova;
+  });
+
+  describe('initialize', () => {
+    it('should resolve successfully when plugin is available', async () => {
+      await expectAsync(service.initialize()).toBeResolved();
+    });
+
+    it('should resolve successfully when plugin is not available', async () => {
+      delete (window as any).cordova;
+      await expectAsync(service.initialize()).toBeResolved();
+    });
+  });
+
+  describe('logCustomEvent', () => {
+    it('should log custom event successfully', async () => {
+      const eventName = 'TEST_EVENT';
+      const properties = { test: 'value' };
+      
+      // Setup mock to call success callback
+      mockPlugin.logCustomEvent.and.callFake((name: string, props: any, success: Function) => {
+        success();
+      });
+
+      await expectAsync(service.logCustomEvent(eventName, properties)).toBeResolved();
+      
+      expect(mockPlugin.logCustomEvent).toHaveBeenCalledWith(
+        eventName,
+        properties,
+        jasmine.any(Function),
+        jasmine.any(Function)
+      );
+      expect(mockPlugin.requestImmediateDataFlush).toHaveBeenCalled();
+    });
+
+    it('should handle error when logging custom event fails', async () => {
+      const eventName = 'TEST_EVENT';
+      const error = 'Failed to log event';
+      
+      // Setup mock to call error callback
+      mockPlugin.logCustomEvent.and.callFake((name: string, props: any, success: Function, failure: Function) => {
+        failure(error);
+      });
+
+      await expectAsync(service.logCustomEvent(eventName)).toBeRejected();
+      expect(mockPlugin.logCustomEvent).toHaveBeenCalled();
+    });
+
+    it('should resolve when plugin is not available', async () => {
+      delete (window as any).cordova;
+      
+      await expectAsync(service.logCustomEvent('TEST_EVENT')).toBeResolved();
+    });
+
+    it('should use empty object for properties when not provided', async () => {
+      mockPlugin.logCustomEvent.and.callFake((name: string, props: any, success: Function) => {
+        success();
+      });
+
+      await service.logCustomEvent('TEST_EVENT');
+      
+      expect(mockPlugin.logCustomEvent).toHaveBeenCalledWith(
+        'TEST_EVENT',
+        {},
+        jasmine.any(Function),
+        jasmine.any(Function)
+      );
+    });
+  });
+
+  describe('requestContentCardsRefresh', () => {
+    it('should request content cards refresh successfully', async () => {
+      await service.requestContentCardsRefresh();
+      expect(mockPlugin.requestContentCardsRefresh).toHaveBeenCalled();
+    });
+
+    it('should handle case when plugin is not available', async () => {
+      delete (window as any).cordova;
+      
+      await expectAsync(service.requestContentCardsRefresh()).toBeResolved();
+    });
+
+    it('should throw error when refresh fails', async () => {
+      mockPlugin.requestContentCardsRefresh.and.throwError('Network error');
+      
+      await expectAsync(service.requestContentCardsRefresh()).toBeRejected();
+    });
+  });
+
+  describe('getContentCards', () => {
+    it('should get content cards successfully', async () => {
+      const mockCards: BrazeContentCard[] = [
+        {
+          id: '1',
+          title: 'Test Card',
+          cardDescription: 'Test Description',
+          created: Date.now() / 1000,
+          expiresAt: Date.now() / 1000 + 3600,
+          viewed: false,
+          clicked: false,
+          pinned: false,
+          dismissed: false,
+          dismissible: true,
+          openURLInWebView: false,
+          domain: 'test.com',
+          type: 'CLASSIC',
+          extras: {}
+        }
+      ];
+
+      mockPlugin.getContentCardsFromCache.and.callFake((success: Function) => {
+        success(mockCards);
+      });
+
+      const result = await service.getContentCards();
+      
+      expect(result).toEqual(mockCards);
+      expect(mockPlugin.getContentCardsFromCache).toHaveBeenCalled();
+    });
+
+    it('should return empty array when plugin is not available', async () => {
+      delete (window as any).cordova;
+      
+      const result = await service.getContentCards();
+      expect(result).toEqual([]);
+    });
+
+    it('should handle error when getting content cards fails', async () => {
+      const error = 'Failed to get cards';
+      
+      mockPlugin.getContentCardsFromCache.and.callFake((success: Function, failure: Function) => {
+        failure(error);
+      });
+
+      await expectAsync(service.getContentCards()).toBeRejected();
+    });
+
+    it('should return empty array when cards is null', async () => {
+      mockPlugin.getContentCardsFromCache.and.callFake((success: Function) => {
+        success(null);
+      });
+
+      const result = await service.getContentCards();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('logContentCardImpression', () => {
+    it('should log content card impression successfully', async () => {
+      const cardId = 'card123';
+      
+      await service.logContentCardImpression(cardId);
+      expect(mockPlugin.logContentCardImpression).toHaveBeenCalledWith(cardId);
+    });
+
+    it('should handle case when plugin is not available', async () => {
+      delete (window as any).cordova;
+      
+      await expectAsync(service.logContentCardImpression('card123')).toBeResolved();
+    });
+
+    it('should throw error when logging impression fails', async () => {
+      mockPlugin.logContentCardImpression.and.throwError('Network error');
+      
+      await expectAsync(service.logContentCardImpression('card123')).toBeRejected();
+    });
+  });
+
+  describe('logContentCardClicked', () => {
+    it('should log content card click successfully', async () => {
+      const cardId = 'card123';
+      
+      await service.logContentCardClicked(cardId);
+      expect(mockPlugin.logContentCardClicked).toHaveBeenCalledWith(cardId);
+    });
+
+    it('should handle case when plugin is not available', async () => {
+      delete (window as any).cordova;
+      
+      await expectAsync(service.logContentCardClicked('card123')).toBeResolved();
+    });
+  });
+
+  describe('logContentCardDismissed', () => {
+    it('should log content card dismissal successfully', async () => {
+      const cardId = 'card123';
+      
+      await service.logContentCardDismissed(cardId);
+      expect(mockPlugin.logContentCardDismissed).toHaveBeenCalledWith(cardId);
+    });
+
+    it('should handle case when plugin is not available', async () => {
+      delete (window as any).cordova;
+      
+      await expectAsync(service.logContentCardDismissed('card123')).toBeResolved();
+    });
+
+    it('should throw error when logging dismissal fails', async () => {
+      mockPlugin.logContentCardDismissed.and.throwError('Network error');
+      
+      await expectAsync(service.logContentCardDismissed('card123')).toBeRejected();
+    });
+  });
+});

--- a/src/app/shared/services/inbox.service.spec.ts
+++ b/src/app/shared/services/inbox.service.spec.ts
@@ -1,0 +1,242 @@
+import { TestBed } from '@angular/core/testing';
+import { InboxService } from './inbox.service';
+import { BrazeContentCard } from './braze.service';
+
+describe('InboxService', () => {
+  let service: InboxService;
+
+  const mockCard: BrazeContentCard = {
+    id: '1',
+    title: 'Test Card',
+    cardDescription: 'Test Description',
+    created: Date.now() / 1000,
+    expiresAt: Date.now() / 1000 + 3600,
+    viewed: false,
+    clicked: false,
+    pinned: false,
+    dismissed: false,
+    dismissible: true,
+    openURLInWebView: false,
+    domain: 'test.com',
+    type: 'CLASSIC',
+    extras: {},
+    image: undefined,
+    url: undefined
+  };
+
+  const mockCard2: BrazeContentCard = {
+    ...mockCard,
+    id: '2',
+    title: 'Test Card 2',
+    viewed: true
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [InboxService]
+    });
+    service = TestBed.inject(InboxService);
+  });
+
+  describe('initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should start with empty cards array', () => {
+      expect(service.cards()).toEqual([]);
+    });
+
+    it('should start with unread count of 0', () => {
+      expect(service.unreadCount()).toBe(0);
+    });
+  });
+
+  describe('addCard', () => {
+    it('should add a card to the inbox', () => {
+      service.addCard(mockCard);
+      
+      expect(service.cards()).toContain(mockCard);
+      expect(service.cards().length).toBe(1);
+    });
+
+    it('should add new cards to the beginning of the array', () => {
+      service.addCard(mockCard);
+      service.addCard(mockCard2);
+      
+      expect(service.cards()[0]).toEqual(mockCard2);
+      expect(service.cards()[1]).toEqual(mockCard);
+    });
+
+    it('should update unread count when adding unread card', () => {
+      service.addCard(mockCard); // unread
+      expect(service.unreadCount()).toBe(1);
+      
+      service.addCard(mockCard2); // read
+      expect(service.unreadCount()).toBe(1);
+    });
+  });
+
+  describe('addCards', () => {
+    it('should add multiple cards to the inbox', () => {
+      const newCards = [mockCard, mockCard2];
+      service.addCards(newCards);
+      
+      expect(service.cards().length).toBe(2);
+      expect(service.cards()).toContain(mockCard);
+      expect(service.cards()).toContain(mockCard2);
+    });
+
+    it('should handle empty array', () => {
+      service.addCards([]);
+      expect(service.cards().length).toBe(0);
+    });
+
+    it('should preserve existing cards when adding new ones', () => {
+      const existingCard = { ...mockCard, id: 'existing' };
+      service.addCard(existingCard);
+      
+      service.addCards([mockCard, mockCard2]);
+      
+      expect(service.cards().length).toBe(3);
+      expect(service.cards()).toContain(existingCard);
+    });
+  });
+
+  describe('setCards', () => {
+    it('should replace all cards', () => {
+      service.addCard(mockCard);
+      expect(service.cards().length).toBe(1);
+      
+      service.setCards([mockCard2]);
+      
+      expect(service.cards().length).toBe(1);
+      expect(service.cards()[0]).toEqual(mockCard2);
+    });
+
+    it('should handle empty array', () => {
+      service.addCard(mockCard);
+      service.setCards([]);
+      
+      expect(service.cards().length).toBe(0);
+    });
+  });
+
+  describe('markAsViewed', () => {
+    it('should mark a card as viewed', () => {
+      service.addCard(mockCard);
+      expect(service.unreadCount()).toBe(1);
+      
+      service.markAsViewed('1');
+      
+      expect(service.cards()[0].viewed).toBe(true);
+      expect(service.unreadCount()).toBe(0);
+    });
+
+    it('should not affect other cards', () => {
+      service.addCards([mockCard, mockCard2]);
+      
+      service.markAsViewed('1');
+      
+      expect(service.cards().find(c => c.id === '1')?.viewed).toBe(true);
+      expect(service.cards().find(c => c.id === '2')?.viewed).toBe(true); // was already true
+    });
+
+    it('should handle non-existent card ID', () => {
+      service.addCard(mockCard);
+      
+      expect(() => service.markAsViewed('nonexistent')).not.toThrow();
+      expect(service.cards()[0].viewed).toBe(false);
+    });
+  });
+
+  describe('dismissCard', () => {
+    it('should remove a card from the inbox', () => {
+      service.addCards([mockCard, mockCard2]);
+      expect(service.cards().length).toBe(2);
+      
+      service.dismissCard('1');
+      
+      expect(service.cards().length).toBe(1);
+      expect(service.cards().find(c => c.id === '1')).toBeUndefined();
+      expect(service.cards().find(c => c.id === '2')).toBeDefined();
+    });
+
+    it('should update unread count when dismissing unread card', () => {
+      service.addCards([mockCard, mockCard2]); // one unread, one read
+      expect(service.unreadCount()).toBe(1);
+      
+      service.dismissCard('1'); // dismiss unread card
+      
+      expect(service.unreadCount()).toBe(0);
+    });
+
+    it('should handle non-existent card ID', () => {
+      service.addCard(mockCard);
+      const initialLength = service.cards().length;
+      
+      expect(() => service.dismissCard('nonexistent')).not.toThrow();
+      expect(service.cards().length).toBe(initialLength);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('should remove all cards', () => {
+      service.addCards([mockCard, mockCard2]);
+      expect(service.cards().length).toBe(2);
+      
+      service.clearAll();
+      
+      expect(service.cards().length).toBe(0);
+      expect(service.unreadCount()).toBe(0);
+    });
+
+    it('should handle empty inbox', () => {
+      expect(() => service.clearAll()).not.toThrow();
+      expect(service.cards().length).toBe(0);
+    });
+  });
+
+  describe('unreadCount computed signal', () => {
+    it('should calculate unread count correctly', () => {
+      expect(service.unreadCount()).toBe(0);
+      
+      service.addCard(mockCard); // unread
+      expect(service.unreadCount()).toBe(1);
+      
+      service.addCard(mockCard2); // read
+      expect(service.unreadCount()).toBe(1);
+      
+      service.markAsViewed('1');
+      expect(service.unreadCount()).toBe(0);
+    });
+
+    it('should update when cards are dismissed', () => {
+      service.addCards([mockCard, { ...mockCard, id: '3', viewed: false }]);
+      expect(service.unreadCount()).toBe(2);
+      
+      service.dismissCard('1');
+      expect(service.unreadCount()).toBe(1);
+      
+      service.dismissCard('3');
+      expect(service.unreadCount()).toBe(0);
+    });
+  });
+
+  describe('cards readonly signal', () => {
+    it('should provide readonly access to cards', () => {
+      const cards = service.cards;
+      expect(typeof cards).toBe('function'); // signals are functions
+      expect(cards()).toEqual([]);
+    });
+
+    it('should reflect changes when cards are modified', () => {
+      const cards = service.cards;
+      expect(cards().length).toBe(0);
+      
+      service.addCard(mockCard);
+      expect(cards().length).toBe(1);
+      expect(cards()[0]).toEqual(mockCard);
+    });
+  });
+});

--- a/src/app/shared/services/push-notification.service.spec.ts
+++ b/src/app/shared/services/push-notification.service.spec.ts
@@ -1,0 +1,435 @@
+import { TestBed } from '@angular/core/testing';
+import { PushNotificationService } from './push-notification.service';
+import { BrazeService, BrazeContentCard } from './braze.service';
+import { InboxService } from './inbox.service';
+import { PushNotifications } from '@capacitor/push-notifications';
+
+describe('PushNotificationService', () => {
+  let service: PushNotificationService;
+  let mockBrazeService: jasmine.SpyObj<BrazeService>;
+  let mockInboxService: jasmine.SpyObj<InboxService>;
+
+  const mockContentCard: BrazeContentCard = {
+    id: '1',
+    title: 'Test Card',
+    cardDescription: 'Test Description',
+    created: Date.now() / 1000,
+    expiresAt: Date.now() / 1000 + 3600,
+    viewed: false,
+    clicked: false,
+    pinned: false,
+    dismissed: false,
+    dismissible: true,
+    openURLInWebView: false,
+    domain: 'test.com',
+    type: 'CLASSIC',
+    extras: {},
+    image: undefined,
+    url: undefined
+  };
+
+  beforeEach(() => {
+    // Create service mocks
+    mockBrazeService = jasmine.createSpyObj('BrazeService', [
+      'initialize',
+      'requestContentCardsRefresh',
+      'getContentCards'
+    ]);
+    mockInboxService = jasmine.createSpyObj('InboxService', ['setCards', 'addCards']);
+
+    // Mock PushNotifications
+    spyOn(PushNotifications, 'requestPermissions').and.returnValue(Promise.resolve({ receive: 'granted' }));
+    spyOn(PushNotifications, 'register').and.returnValue(Promise.resolve());
+    spyOn(PushNotifications, 'addListener').and.returnValue(Promise.resolve({ remove: jasmine.createSpy() }));
+
+    TestBed.configureTestingModule({
+      providers: [
+        PushNotificationService,
+        { provide: BrazeService, useValue: mockBrazeService },
+        { provide: InboxService, useValue: mockInboxService }
+      ]
+    });
+    service = TestBed.inject(PushNotificationService);
+  });
+
+  describe('Service Initialization', () => {
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('should inject required services', () => {
+      expect(service['brazeService']).toBeDefined();
+      expect(service['inboxService']).toBeDefined();
+    });
+  });
+
+  describe('init method', () => {
+    beforeEach(() => {
+      mockBrazeService.initialize.and.returnValue(Promise.resolve());
+      mockBrazeService.requestContentCardsRefresh.and.returnValue(Promise.resolve());
+      mockBrazeService.getContentCards.and.returnValue(Promise.resolve([mockContentCard]));
+      spyOn(service as any, 'setupPushListeners');
+      spyOn(service as any, 'registerPush').and.returnValue(Promise.resolve());
+      spyOn(service as any, 'loadInitialContentCards').and.returnValue(Promise.resolve());
+    });
+
+    it('should initialize Braze SDK', async () => {
+      await service.init();
+      expect(mockBrazeService.initialize).toHaveBeenCalled();
+    });
+
+    it('should setup push listeners', async () => {
+      await service.init();
+      expect(service['setupPushListeners']).toHaveBeenCalled();
+    });
+
+    it('should register for push notifications', async () => {
+      await service.init();
+      expect(service['registerPush']).toHaveBeenCalled();
+    });
+
+    it('should load initial content cards', async () => {
+      await service.init();
+      expect(service['loadInitialContentCards']).toHaveBeenCalled();
+    });
+
+    it('should handle Braze initialization error', async () => {
+      const error = new Error('Braze init failed');
+      mockBrazeService.initialize.and.returnValue(Promise.reject(error));
+      spyOn(console, 'error');
+
+      await service.init();
+
+      expect(console.error).toHaveBeenCalledWith('Error initializing Braze SDK:', error);
+      // Should continue with other initialization steps
+      expect(service['setupPushListeners']).toHaveBeenCalled();
+    });
+
+    it('should log initialization steps', async () => {
+      spyOn(console, 'log');
+
+      await service.init();
+
+      expect(console.log).toHaveBeenCalledWith('Initializing PushNotificationService...');
+      expect(console.log).toHaveBeenCalledWith('Braze SDK initialized in PushNotificationService');
+      expect(console.log).toHaveBeenCalledWith('PushNotificationService initialization complete');
+    });
+  });
+
+  describe('loadInitialContentCards', () => {
+    beforeEach(() => {
+      mockBrazeService.requestContentCardsRefresh.and.returnValue(Promise.resolve());
+      mockBrazeService.getContentCards.and.returnValue(Promise.resolve([mockContentCard]));
+    });
+
+    it('should request content cards refresh', async () => {
+      await service['loadInitialContentCards']();
+      expect(mockBrazeService.requestContentCardsRefresh).toHaveBeenCalled();
+    });
+
+    it('should get content cards from cache', async () => {
+      await service['loadInitialContentCards']();
+      expect(mockBrazeService.getContentCards).toHaveBeenCalled();
+    });
+
+    it('should set cards in inbox service', async () => {
+      await service['loadInitialContentCards']();
+      expect(mockInboxService.setCards).toHaveBeenCalledWith([mockContentCard]);
+    });
+
+    it('should handle empty content cards', async () => {
+      mockBrazeService.getContentCards.and.returnValue(Promise.resolve([]));
+
+      await service['loadInitialContentCards']();
+
+      expect(mockInboxService.setCards).toHaveBeenCalledWith([]);
+    });
+
+    it('should handle errors during content card loading', async () => {
+      const error = new Error('Failed to load cards');
+      mockBrazeService.getContentCards.and.returnValue(Promise.reject(error));
+      spyOn(console, 'error');
+
+      await service['loadInitialContentCards']();
+
+      expect(console.error).toHaveBeenCalledWith('Error loading initial content cards:', error);
+    });
+
+    it('should include delay between refresh and fetch', async () => {
+      const startTime = Date.now();
+      await service['loadInitialContentCards']();
+      const endTime = Date.now();
+
+      expect(endTime - startTime).toBeGreaterThanOrEqual(1000); // At least 1 second delay
+    });
+
+    it('should log loading steps', async () => {
+      spyOn(console, 'log');
+
+      await service['loadInitialContentCards']();
+
+      expect(console.log).toHaveBeenCalledWith('Loading initial content cards...');
+      expect(console.log).toHaveBeenCalledWith('Loaded 1 content cards into inbox');
+    });
+  });
+
+  describe('registerPush', () => {
+    it('should request push notification permissions', async () => {
+      await service['registerPush']();
+      expect(PushNotifications.requestPermissions).toHaveBeenCalled();
+    });
+
+    it('should register for push notifications when permission granted', async () => {
+      PushNotifications.requestPermissions = jasmine.createSpy().and.returnValue(
+        Promise.resolve({ receive: 'granted' })
+      );
+
+      await service['registerPush']();
+
+      expect(PushNotifications.register).toHaveBeenCalled();
+    });
+
+    it('should handle permission denied', async () => {
+      PushNotifications.requestPermissions = jasmine.createSpy().and.returnValue(
+        Promise.resolve({ receive: 'denied' })
+      );
+      spyOn(console, 'warn');
+
+      await service['registerPush']();
+
+      expect(console.warn).toHaveBeenCalledWith('Push notification permission denied');
+      expect(PushNotifications.register).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors during registration', async () => {
+      const error = new Error('Registration failed');
+      PushNotifications.requestPermissions = jasmine.createSpy().and.returnValue(Promise.reject(error));
+      spyOn(console, 'error');
+
+      await service['registerPush']();
+
+      expect(console.error).toHaveBeenCalledWith('Error registering for push notifications:', error);
+    });
+
+    it('should log registration success', async () => {
+      spyOn(console, 'log');
+
+      await service['registerPush']();
+
+      expect(console.log).toHaveBeenCalledWith('Push notifications registered successfully');
+    });
+  });
+
+  describe('setupPushListeners', () => {
+    it('should setup push notification listeners', () => {
+      service['setupPushListeners']();
+
+      expect(PushNotifications.addListener).toHaveBeenCalledWith('registration' as any, jasmine.any(Function));
+      expect(PushNotifications.addListener).toHaveBeenCalledWith('registrationError' as any, jasmine.any(Function));
+      expect(PushNotifications.addListener).toHaveBeenCalledWith('pushNotificationReceived' as any, jasmine.any(Function));
+      expect(PushNotifications.addListener).toHaveBeenCalledWith('pushNotificationActionPerformed', jasmine.any(Function));
+    });
+
+    it('should handle registration success', () => {
+      spyOn(console, 'log');
+      service['setupPushListeners']();
+
+      // Get the registration listener
+      const registrationCall = (PushNotifications.addListener as jasmine.Spy).calls.all()
+        .find(call => call.args[0] === 'registration');
+      const registrationHandler = registrationCall?.args[1];
+
+      const token = { value: 'test-token' };
+      registrationHandler(token);
+
+      expect(console.log).toHaveBeenCalledWith('Push registration success, token:', 'test-token');
+    });
+
+    it('should handle registration error', () => {
+      spyOn(console, 'error');
+      service['setupPushListeners']();
+
+      const registrationErrorCall = (PushNotifications.addListener as jasmine.Spy).calls.all()
+        .find(call => call.args[0] === 'registrationError');
+      const errorHandler = registrationErrorCall?.args[1];
+
+      const error = { error: 'Registration failed' };
+      errorHandler(error);
+
+      expect(console.error).toHaveBeenCalledWith('Push registration error:', error);
+    });
+  });
+
+  describe('push notification handling', () => {
+    beforeEach(() => {
+      service['setupPushListeners']();
+    });
+
+    it('should handle received push notification', () => {
+      spyOn(console, 'log');
+      spyOn(service as any, 'handleBrazePushNotification');
+
+      const receivedCall = (PushNotifications.addListener as jasmine.Spy).calls.all()
+        .find(call => call.args[0] === 'pushNotificationReceived');
+      const receivedHandler = receivedCall?.args[1];
+
+      const notification = {
+        id: 'test-notification-1',
+        title: 'Test',
+        body: 'Test notification',
+        data: { type: 'braze' }
+      };
+      receivedHandler(notification);
+
+      expect(console.log).toHaveBeenCalledWith('Push notification received:', notification);
+      expect(service['handleBrazePushNotification']).toHaveBeenCalledWith(notification);
+    });
+
+    it('should handle push notification action', () => {
+      spyOn(console, 'log');
+      spyOn(service as any, 'handleBrazePushNotification');
+
+      const actionCall = (PushNotifications.addListener as jasmine.Spy).calls.all()
+        .find(call => call.args[0] === 'pushNotificationActionPerformed');
+      const actionHandler = actionCall?.args[1];
+
+      const action = {
+        notification: {
+          title: 'Test',
+          body: 'Test notification',
+          data: { type: 'braze' }
+        },
+        actionId: 'tap'
+      };
+      actionHandler(action);
+
+      expect(console.log).toHaveBeenCalledWith('Push notification action performed:', action);
+      expect(service['handleBrazePushNotification']).toHaveBeenCalledWith(jasmine.objectContaining({
+        title: action.notification.title,
+        body: action.notification.body
+      }));
+    });
+  });
+
+  describe('handleBrazePushNotification', () => {
+    beforeEach(() => {
+      mockBrazeService.requestContentCardsRefresh.and.returnValue(Promise.resolve());
+      mockBrazeService.getContentCards.and.returnValue(Promise.resolve([mockContentCard]));
+    });
+
+    it('should handle Braze notifications', async () => {
+      const notification = {
+        id: "test-notification",
+        data: { 
+          source: 'braze',
+          campaign_id: 'test-campaign'
+        }
+      };
+
+      await service['handleBrazePushNotification'](notification);
+
+      expect(mockBrazeService.requestContentCardsRefresh).toHaveBeenCalled();
+    });
+
+    it('should detect Braze notifications by different identifiers', async () => {
+      const brazeNotifications = [
+        { id: 'test1', data: { source: 'braze' } },
+        { id: 'test2', data: { campaign_id: 'test' } },
+        { id: 'test3', data: { canvas_id: 'test' } },
+        { id: 'test4', data: { ab_campaign_id: 'test' } }
+      ];
+
+      for (const notification of brazeNotifications) {
+        await service['handleBrazePushNotification'](notification);
+        expect(mockBrazeService.requestContentCardsRefresh).toHaveBeenCalled();
+        mockBrazeService.requestContentCardsRefresh.calls.reset();
+      }
+    });
+
+    it('should skip non-Braze notifications', async () => {
+      const notification = {
+        id: "test-notification",
+        data: { 
+          type: 'other',
+          message: 'Not from Braze'
+        }
+      };
+
+      await service['handleBrazePushNotification'](notification);
+
+      expect(mockBrazeService.requestContentCardsRefresh).not.toHaveBeenCalled();
+    });
+
+    it('should handle notifications without data', async () => {
+      const notification = {
+        id: "test-notification",
+        data: {}
+      };
+
+      expect(async () => await service['handleBrazePushNotification'](notification)).not.toThrow();
+      expect(mockBrazeService.requestContentCardsRefresh).not.toHaveBeenCalled();
+    });
+
+    it('should refresh content cards after Braze notification', async () => {
+      const notification = {
+        id: "test-notification", data: { source: 'braze' } };
+
+      await service['handleBrazePushNotification'](notification);
+
+      expect(mockBrazeService.requestContentCardsRefresh).toHaveBeenCalled();
+      expect(mockBrazeService.getContentCards).toHaveBeenCalled();
+      expect(mockInboxService.addCards).toHaveBeenCalledWith([mockContentCard]);
+    });
+
+    it('should handle errors during notification processing', async () => {
+      const error = new Error('Processing failed');
+      mockBrazeService.requestContentCardsRefresh.and.returnValue(Promise.reject(error));
+      spyOn(console, 'error');
+
+      const notification = {
+        id: "test-notification", data: { source: 'braze' } };
+      await service['handleBrazePushNotification'](notification);
+
+      expect(console.error).toHaveBeenCalledWith('Error handling push notification:', error);
+    });
+  });
+
+  describe('Notification Type Detection Logic', () => {
+    it('should detect Braze inbox notifications by type', () => {
+      // Test the inline logic that would be used in handleBrazePushNotification
+      const notification = {
+        id: "test-notification", data: { type: 'inbox' } };
+      const extras = notification.data || {};
+      const isInboxNotification = (extras as any).type === 'inbox' || (extras as any)._ab === 'true';
+      
+      expect(isInboxNotification).toBe(true);
+    });
+
+    it('should detect Braze notifications by _ab flag', () => {
+      const notification = {
+        id: "test-notification", data: { _ab: 'true' } };
+      const extras = notification.data || {};
+      const isInboxNotification = (extras as any).type === 'inbox' || (extras as any)._ab === 'true';
+      
+      expect(isInboxNotification).toBe(true);
+    });
+
+    it('should not detect non-Braze notifications', () => {
+      const notification = {
+        id: "test-notification", data: { type: 'other' } };
+      const extras = notification.data || {};
+      const isInboxNotification = (extras as any).type === 'inbox' || (extras as any)._ab === 'true';
+      
+      expect(isInboxNotification).toBe(false);
+    });
+
+    it('should handle notifications without data', () => {
+      const notification = {
+        id: "test-notification",};
+      const extras = (notification as any).data || (notification as any).extras || {};
+      const isInboxNotification = (extras as any).type === 'inbox' || (extras as any)._ab === 'true';
+      
+      expect(isInboxNotification).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- Add unit tests for HomePage with Braze service integration and error handling
- Add unit tests for CompletePage with navigation and survey functionality
- Add unit tests for MmCardComponent with signal-based title management
- Add unit tests for InboxComponent with message display and filtering
- Add unit tests for BrazeService with plugin availability and event logging
- Add unit tests for InboxService with message retrieval and management
- Add unit tests for PushNotificationService with initialization and registration

Coverage includes:
- Component initialisation and template rendering
- Service method calls and error scenarios
- User interaction handling (clicks, navigation)
- Signal-based reactive state management
- Mock configuration for Ionic and Capacitor dependencies
- Async operation testing with proper promise handling
- DOM element selection and attribute validation

All tests follow Angular Testing Utilities best practices with proper
fixture management, spy object configuration and comprehensive assertions.